### PR TITLE
fix property to override default database

### DIFF
--- a/manual/working/javaGuide/main/sql/JavaEbean.md
+++ b/manual/working/javaGuide/main/sql/JavaEbean.md
@@ -23,7 +23,7 @@ The runtime library can be configured by putting the list of packages and/or cla
 ebean.default = ["models.*"]
 ```
 
-This defines a `default` Ebean server, using the `default` data source, which must be properly configured. You can also override the name of the default Ebean server by configuring `ebeanconfig.datasource.default` property. This might be useful if you want to use separate databases for testing and development. You can actually create as many Ebean servers you need, and explicitly define the mapped class for each server:
+This defines a `default` Ebean server, using the `default` data source, which must be properly configured. You can also override the name of the default Ebean server by configuring `play.ebean.defaultDatasource` property. This might be useful if you want to use separate databases for testing and development. You can actually create as many Ebean servers you need, and explicitly define the mapped class for each server:
 
 ```properties
 ebean.orders = ["models.Order", "models.OrderItem"]


### PR DESCRIPTION
Change the property `ebean.datasource.default` to `play.ebean.defaultDatasource`, to set/override the default ebean datasource